### PR TITLE
fix: enforce production security hardening and add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+server/node_modules
+web/node_modules
+server/dist
+web/dist
+server/.env
+server/.env.*
+server/prisma/*.db
+server/prisma/*.db-journal
+server/.debug
+.git
+*.md
+deploy.sh
+.vscode
+.idea
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+# ---- Stage 1: Build ----
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+# 安装系统依赖（Prisma 引擎需要）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# 先复制 package 文件，利用 Docker 层缓存
+COPY package.json package-lock.json* ./
+COPY server/package.json server/package-lock.json* server/
+COPY web/package.json web/package-lock.json* web/
+
+# 安装全部依赖
+RUN npm install --prefix server && npm install --prefix web
+
+# 复制源码
+COPY server/ server/
+COPY web/ web/
+
+# 生成 Prisma Client（linux 二进制）
+RUN npx prisma generate --schema=server/prisma/schema.prisma
+
+# 构建后端 TypeScript
+RUN npm run build --prefix server
+
+# 构建前端
+RUN npm run build --prefix web
+
+# ---- Stage 2: Runtime ----
+FROM node:20-slim AS runtime
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssl ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# 复制后端构建产物 + 依赖
+COPY --from=builder /app/server/dist server/dist
+COPY --from=builder /app/server/node_modules server/node_modules
+COPY --from=builder /app/server/package.json server/package.json
+COPY --from=builder /app/server/prisma server/prisma
+
+# 复制前端构建产物
+COPY --from=builder /app/web/dist web/dist
+
+# SQLite 数据目录（可通过 volume 持久化）
+RUN mkdir -p /app/data
+
+# 数据库 URL — 默认指向容器内持久化路径
+ENV DATABASE_URL="file:/app/data/prod.db"
+ENV NODE_ENV=production
+ENV PORT=3000
+
+EXPOSE 3000
+
+# 健康检查
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:3000/api/health || exit 1
+
+# 数据库迁移 + 启动
+CMD ["sh", "-c", "npx prisma migrate deploy --schema=server/prisma/schema.prisma && node server/dist/index.js"]

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "dayjs": "^1.11.13",
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
+        "express-rate-limit": "^8.5.2",
         "iconv-lite": "^0.6.3",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
@@ -1268,6 +1269,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -1308,6 +1327,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1468,6 +1488,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
+    "express-rate-limit": "^8.5.2",
     "iconv-lite": "^0.6.3",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,12 +5,24 @@ import path from "node:path";
 import { existsSync } from "node:fs";
 import { errorHandler } from "./middleware/error";
 import { router } from "./routes";
-import { isDev } from "./config";
+import { isDev, config } from "./config";
 
 export function createApp() {
   const app = express();
 
-  app.use(cors());
+  const allowedOrigins = process.env.CORS_ORIGIN
+    ? process.env.CORS_ORIGIN.split(",").map((s) => s.trim()).filter(Boolean)
+    : ["http://localhost:5173"];
+
+  app.use(cors({
+    origin: (origin, cb) => {
+      // 允许无 origin 的请求（同源、curl、服务端调用）
+      if (!origin) return cb(null, true);
+      if (allowedOrigins.includes(origin)) return cb(null, true);
+      cb(new Error("CORS 策略拒绝了该请求来源"));
+    },
+    credentials: true,
+  }));
   app.use(express.json({ limit: "1mb" }));
   if (isDev) app.use(morgan("dev"));
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,15 +1,23 @@
 import dotenv from "dotenv";
 dotenv.config();
 
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const isProd = nodeEnv === "production";
+
+const jwtSecret = process.env.JWT_SECRET;
+if (isProd && !jwtSecret) {
+  throw new Error("JWT_SECRET 环境变量必须在生产环境中设置");
+}
+
 export const config = {
   port: Number(process.env.PORT ?? 3000),
-  jwtSecret: process.env.JWT_SECRET ?? "cpu-web-dev-secret",
+  jwtSecret: jwtSecret ?? "cpu-web-dev-secret",
   jwtExpiresIn: process.env.JWT_EXPIRES_IN ?? "7d",
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   jwxtProxyUrl: process.env.JWXT_PROXY_URL ?? "",
   jwxtProxyAuth: process.env.JWXT_PROXY_AUTH ?? "",
   proxyAuth: process.env.PROXY_AUTH ?? "",
   proxyTimeoutMs: Number(process.env.JWXT_PROXY_TIMEOUT_MS ?? 15000),
 };
 
-export const isDev = config.nodeEnv !== "production";
+export const isDev = !isProd;

--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -1,0 +1,19 @@
+import rateLimit from "express-rate-limit";
+
+/** 认证类接口限流：15 分钟内最多 10 次 */
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { code: 429, data: null, message: "请求过于频繁，请稍后再试" },
+});
+
+/** 教务登录限流：15 分钟内最多 10 次 */
+export const jwxtLoginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { code: 429, data: null, message: "教务登录请求过于频繁，请稍后再试" },
+});

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { signToken } from "../utils/jwt";
 import { hashPassword, verifyPassword } from "../utils/password";
 import { Errors, ok } from "../utils/response";
 import { validate } from "../middleware/validate";
+import { authLimiter } from "../middleware/rateLimit";
 import { beginLogin, submitLogin } from "../services/jwxtTransport";
 import { isDev } from "../config";
 import { detectLoginClient } from "../utils/loginClient";
@@ -28,7 +29,7 @@ const registerSchema = z.object({
 //   - 走过学校 SSO 的账号（studentSso=true）禁用此入口，避免与统一身份认证混淆
 //   - 其他账号（新生 / 毕业生 / 站务 / 管理员等）允许凭密码登录
 //   - 公开注册已禁用，账号统一由 admin 后台开通，所以放开 role 限制是安全的
-authRouter.post("/login", validate(loginSchema), async (req, res, next) => {
+authRouter.post("/login", authLimiter, validate(loginSchema), async (req, res, next) => {
   try {
     const { username, password } = req.body;
     const user = await prisma.user.findUnique({ where: { username } });
@@ -60,7 +61,7 @@ authRouter.post("/login", validate(loginSchema), async (req, res, next) => {
 });
 
 // 旧式注册（保留给开发，前端不暴露入口）
-authRouter.post("/register", validate(registerSchema), async (req, res, next) => {
+authRouter.post("/register", authLimiter, validate(registerSchema), async (req, res, next) => {
   try {
     if (!isDev) throw Errors.forbidden("仅支持学校账号登录");
     const { username, password, nickname, college, enrollYear } = req.body;
@@ -91,7 +92,7 @@ authRouter.post("/register", validate(registerSchema), async (req, res, next) =>
 // ============ 学校 SSO 登录（主路径）============
 
 /** 第一步：拿登录页 + 可能的验证码 */
-authRouter.post("/sso-begin", async (_req, res, next) => {
+authRouter.post("/sso-begin", authLimiter, async (_req, res, next) => {
   try {
     const r = await beginLogin();
     ok(res, r);
@@ -103,6 +104,7 @@ authRouter.post("/sso-begin", async (_req, res, next) => {
  */
 authRouter.post(
   "/sso-login",
+  authLimiter,
   validate(z.object({
     pendingId: z.string().min(8),
     username: z.string().min(1),

--- a/server/src/routes/jwxt.ts
+++ b/server/src/routes/jwxt.ts
@@ -3,7 +3,9 @@ import { z } from "zod";
 import { ok, Errors } from "../utils/response";
 import { validate } from "../middleware/validate";
 import { authRequired } from "../middleware/auth";
+import { jwxtLoginLimiter } from "../middleware/rateLimit";
 import { prisma } from "../prisma";
+import { isDev } from "../config";
 import { detectLoginClient } from "../utils/loginClient";
 import {
   beginLogin,
@@ -83,7 +85,7 @@ function ensureEditClient(req: any) {
 }
 
 /** 第一步：获取登录页（拿 lt/execution + 可能的验证码） */
-jwxtRouter.post("/begin-login", async (_req, res, next) => {
+jwxtRouter.post("/begin-login", jwxtLoginLimiter, async (_req, res, next) => {
   try {
     const r = await beginLogin();
     ok(res, r);
@@ -93,6 +95,7 @@ jwxtRouter.post("/begin-login", async (_req, res, next) => {
 /** 第二步：提交账号密码（凭据**仅这一刻**经过后端，不写盘） */
 jwxtRouter.post(
   "/login",
+  jwxtLoginLimiter,
   validate(z.object({
     pendingId: z.string().min(8),
     username: z.string().min(1),
@@ -168,6 +171,7 @@ jwxtRouter.get("/exams", async (req, res, next) => {
  */
 jwxtRouter.post("/debug/snapshot", async (req, res, next) => {
   try {
+    if (!isDev) throw Errors.forbidden();
     const t = getToken(req);
     if (!t) throw Errors.unauthorized("请先登录教务系统");
     const r = await debugSnapshot(t);
@@ -178,12 +182,12 @@ jwxtRouter.post("/debug/snapshot", async (req, res, next) => {
 /** 任意自定义路径（仅 dev 用，用于摸索新页面） */
 jwxtRouter.get("/probe", async (req, res, next) => {
   try {
-    if (process.env.NODE_ENV === "production") throw Errors.forbidden();
+    if (!isDev) throw Errors.forbidden();
     if (isRemoteMode) throw Errors.badRequest("远端模式不支持 probe");
     const t = getToken(req);
     if (!t) throw Errors.unauthorized("请先登录教务系统");
     const p = String(req.query.path ?? "");
-    if (!p.startsWith("/")) throw Errors.badRequest("path 必须以 / 开头");
+    if (!p.startsWith("/") || p.includes("..")) throw Errors.badRequest("非法路径");
     const { jwxtFetchHtml } = await import("../services/jwxtClient");
     const html = await jwxtFetchHtml(t, p);
     ok(res, { html });
@@ -192,6 +196,7 @@ jwxtRouter.get("/probe", async (req, res, next) => {
 
 jwxtRouter.get("/stats", async (_req, res, next) => {
   try {
+    if (!isDev) throw Errors.forbidden();
     ok(res, await sessionStats());
   } catch (e) { next(e); }
 });

--- a/server/src/routes/proxyJwxt.ts
+++ b/server/src/routes/proxyJwxt.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { z } from "zod";
-import { config } from "../config";
+import { config, isDev } from "../config";
 import { validate } from "../middleware/validate";
 import { Errors, ok } from "../utils/response";
 import {
@@ -29,7 +29,10 @@ proxyJwxtRouter.get("/health", (_req, res) => {
 });
 
 proxyJwxtRouter.use((req, _res, next) => {
-  if (!config.proxyAuth) return next();
+  if (!config.proxyAuth) {
+    if (isDev) return next();
+    return next(Errors.server("代理服务未配置鉴权密钥"));
+  }
   if (req.get("X-Proxy-Auth") !== config.proxyAuth) return next(Errors.unauthorized("代理鉴权失败"));
   return next();
 });

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -40,4 +40,12 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.code === "INVALID_ANNOTATION") return;
+        warn(warning);
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Changes
### Security Fixes (Critical/High)
- **JWT Secret**: Throw at startup if `JWT_SECRET` is missing in production — prevents token forgery with the previously hardcoded fallback
- **CORS**: Replace open `cors()` with origin whitelist via `CORS_ORIGIN` env var (defaults to `http://localhost:5173`)
- **Proxy Auth**: Reject all requests when `PROXY_AUTH` is unset in production — previously the proxy middleware was completely bypassed
- **Debug Endpoints**: Gate `/debug/snapshot`, `/probe`, `/stats` behind `isDev` guard; add `..` path traversal protection to `/probe`
- **Rate Limiting**: Add `express-rate-limit` (10 req / 15 min) to all authentication endpoints (`/login`, `/register`, `/sso-begin`, `/sso-login`, jwxt `/begin-login`, `/login`)
### Build
- Suppress `INVALID_ANNOTATION` rollup warning from `@vueuse/core` (harmless `#__PURE__` annotation positioning issue)
### Docker
- Multi-stage `Dockerfile` (node:20-slim): build frontend + backend, runtime serves from single container
- SQLite data persisted at `/app/data` via volume mount
- Health check on `/api/health`
- `Prisma migrate deploy` on container start
## New Environment Variables
| Variable | Required | Default | Description |
|----------|----------|---------|-------------|
| `JWT_SECRET` | **production: yes** | `cpu-web-dev-secret` (dev only) | JWT signing secret |
| `CORS_ORIGIN` | no | `http://localhost:5173` | Comma-separated allowed origins |
## Docker Usage
```bash
docker build -t cpu-web .
docker run -d -p 3000:3000 -v cpu-web-data:/app/data \
  -e JWT_SECRET="your-secret" \
  -e CORS_ORIGIN="https://your-domain.com" \
  cpu-web
```