### PR TITLE
fix(web): gate freshman notice by auth state

### DIFF
--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -522,10 +522,10 @@ const drawerItems = computed(() => {
   if (auth.canAccessForum && site.features.forum) items.push({ id: "system-post", to: "/post", label: "发帖", icon: Edit });
   items.push({ id: "system-messages", to: "/messages", label: "消息", icon: Message });
   if (auth.canAccessModuleAdmin) items.push({ id: "system-admin", to: "/admin", label: "管理后台", icon: Tools });
-  for (const item of site.topNavigation.filter((candidate) => candidate.showInDrawer && navigationItemVisible(candidate))) {
+  if (!items.some((item) => item.to === "/download")) items.push({ id: "system-download", to: "/download", label: "客户端下载", icon: Download });
+  for (const item of site.topNavigation.filter((candidate) => candidate.to !== "/download" && candidate.showInDrawer && navigationItemVisible(candidate))) {
     items.push({ id: `configured-${item.id}`, to: item.to, label: item.fullLabel || item.label, icon: navigationIconMap[item.icon], openInNewTab: item.openInNewTab });
   }
-  if (!items.some((item) => item.to === "/download")) items.push({ id: "system-download", to: "/download", label: "客户端下载", icon: Download });
   if (!items.some((item) => item.to === "/search")) items.push({ id: "system-search", to: "/search", label: "拾间AI", icon: Search });
   return items;
 });

--- a/web/src/views/jwxt/Index.vue
+++ b/web/src/views/jwxt/Index.vue
@@ -339,7 +339,12 @@ const identityBadgeText = computed(() => (
 function syncFreshmanNotice() {
   // 教务页是缓存优先路由，首次挂载时站内会话可能还在后台探测。
   // 会话确认前不弹提示；确认已登录后也必须保持关闭。
-  if (!auth.ready || (auth.token && !auth.user)) {
+  if (
+    !auth.ready
+    || auth.isLoggedIn
+    || jwxt.isLoggedIn
+    || (auth.token && !auth.user)
+  ) {
     freshmanNoticeVisible.value = false;
     return;
   }
@@ -348,13 +353,15 @@ function syncFreshmanNotice() {
 
 onMounted(() => {
   disposed = false;
+  // 先恢复教务本地会话，再做新生提示判断，避免已连接教务的用户被误判为访客。
+  jwxt.hydrate();
   setupMobileViewportWatcher();
   syncFreshmanNotice();
   void initPage();
 });
 
 watch(
-  () => [auth.ready, auth.isLoggedIn] as const,
+  () => [auth.ready, auth.isLoggedIn, jwxt.isLoggedIn, hasCachedData.value] as const,
   () => syncFreshmanNotice(),
 );
 

--- a/web/src/views/jwxt/Index.vue
+++ b/web/src/views/jwxt/Index.vue
@@ -336,12 +336,27 @@ const identityBadgeText = computed(() => (
   isGraduateIdentity.value ? "自动识别：研究生课表" : "自动识别：本科教务"
 ));
 
+function syncFreshmanNotice() {
+  // 教务页是缓存优先路由，首次挂载时站内会话可能还在后台探测。
+  // 会话确认前不弹提示；确认已登录后也必须保持关闭。
+  if (!auth.ready || (auth.token && !auth.user)) {
+    freshmanNoticeVisible.value = false;
+    return;
+  }
+  freshmanNoticeVisible.value = !auth.isLoggedIn && shouldShowFreshmanNotice();
+}
+
 onMounted(() => {
   disposed = false;
   setupMobileViewportWatcher();
-  freshmanNoticeVisible.value = shouldShowFreshmanNotice();
+  syncFreshmanNotice();
   void initPage();
 });
+
+watch(
+  () => [auth.ready, auth.isLoggedIn] as const,
+  () => syncFreshmanNotice(),
+);
 
 onBeforeUnmount(() => {
   disposed = true;


### PR DESCRIPTION
## 变更

- 将客户端下载入口固定加入右上角快捷面板，并避免与配置导航重复。
- 教务页等待登录状态探测完成后再判断新生提示。
- 已登录或仍持有会话标记但用户资料尚未恢复时，不显示新生弹窗。

## 原因

教务页采用缓存优先加载，组件挂载时认证状态可能尚未恢复，导致已登录用户被误判为未登录并看到新生提示。

## 验证

- `git diff --check`
- `npm run build --prefix web`